### PR TITLE
Pass CLI exit code to Actions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,11 @@ fi
 
 CMDOUT=$(eval $command)
 
+ret=$?
+if [ $ret -ne 0 ]; then
+  exit $ret
+fi
+
 username=$(jq -n "$CMDOUT" | jq '.username')
 password=$(jq -n "$CMDOUT" | jq '.plain_text')
 hostname=$(jq -n "$CMDOUT" | jq '.database_branch.access_host_url')


### PR DESCRIPTION
This update will pass the exit code from the CLI operations up to the Actions platform. This will properly flag the workflow step as a failure if something goes wrong while executing.