### PR TITLE
Add Mask for Username and Password

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,8 @@ fi
 username=$(jq -n "$CMDOUT" | jq -r '.username')
 password=$(jq -n "$CMDOUT" | jq -r '.plain_text')
 hostname=$(jq -n "$CMDOUT" | jq -r '.database_branch.access_host_url')
+echo "::add-mask::$username"
+echo "::add-mask::$password"
 echo "username=$username" >> $GITHUB_OUTPUT
 echo "password=$password" >> $GITHUB_OUTPUT
 echo "hostname=$hostname" >> $GITHUB_OUTPUT


### PR DESCRIPTION
GitHub allows us to make the logs incase the given strings get echo'd out. See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#masking-a-value-in-a-log.

I could be convinced that `username` might not be necessary to mask.

Or could just mask it all based on an action variable flag? Something like `mask_values`?

Let me know your thoughts!